### PR TITLE
Swap resume template to avoid future broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@ Free for personal and commercial use under the CCA 3.0 license (html5up.net/lice
                                 <li><a href="#talent" class="scrolly">BYU Developers Talent Network</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://joshcockrell.com/resume_template.docx" target="_blank">Resume Template</a></li>
+                        <li><a href="https://joshcockrell.com/resume-template" target="_blank">Resume Template</a></li>
                         <li><a href="partnership_guide.pdf" target="_blank">Become a Corporate Partner</a></li>
                         <li><a href="officers" target="_blank">Officers</a></li>
                         <li><a href="https://docs.google.com/forms/d/e/1FAIpQLScKH52O1K8bBh1v-Epv-FbxfZmowHpPzJRkEk5lqDlBZO2VtQ/viewform?usp=sf_link" target="_blank">Apply For Leadership</a></li>


### PR DESCRIPTION
Just removing the .docx extension so that the template can be modified without breaking the link here.